### PR TITLE
Fixed some bugs in unittests

### DIFF
--- a/src/maze.py
+++ b/src/maze.py
@@ -204,7 +204,7 @@ class Maze(object):
         visited_cells = list()                  # Stack of visited cells for backtracking
 
         print("\nGenerating the maze with depth-first search...")
-        time_start = time.clock()
+        time_start = time.time()
 
         while visit_counter < self.grid_size:     # While there are unvisited cells
             neighbour_indices = self.find_neighbours(k_curr, l_curr)    # Find neighbour indicies
@@ -226,7 +226,7 @@ class Maze(object):
                 path.append((k_curr, l_curr))   # Add coordinates to part of generation path
 
         print("Number of moves performed: {}".format(len(path)))
-        print("Execution time for algorithm: {:.4f}".format(time.clock() - time_start))
+        print("Execution time for algorithm: {:.4f}".format(time.time() - time_start))
 
         self.grid[self.entry_coor[0]][self.entry_coor[1]].set_as_entry_exit("entry",
             self.num_rows-1, self.num_cols-1)

--- a/tests/cell_tests.py
+++ b/tests/cell_tests.py
@@ -49,7 +49,7 @@ class TestCell(unittest.TestCase):
         # Check if we can make the exit on the right wall in a corner
         cell = Cell(2, 2)
         cell.set_as_entry_exit(True, 2, 2)
-        self.assertEqual(cell.walls["right"], False)
+        self.assertEqual(cell.walls["right"], True)
 
     def test_remove_walls(self):
         """Test the Cell::remove_walls method"""
@@ -60,7 +60,7 @@ class TestCell(unittest.TestCase):
 
         # Remove the cell to the left
         cell = Cell(0, 1)
-        cell.remove_walls(1, 0)
+        cell.remove_walls(0, 0)
         self.assertEqual(cell.walls["left"], False)
 
         # Remove the cell above
@@ -79,30 +79,32 @@ class TestCell(unittest.TestCase):
             Note that cells are constructed with neighbors on each side.
             We'll need to remove some walls to get full coverage.
         """
+        # Create a base cell for which we will be testing whether walls exist
+        cell = Cell (1, 1)
 
-        # We should have walls on all sides of a new cell
-        cell = Cell (0, 0)
-        self.assertEqual(cell.walls, {"top": True, "right": True, "bottom": True, "left": True})
+        # Create a cell appearing to the top of this cell
+        cell_top = Cell(0,1)
+        # Create a cell appearing to the right of this cell
+        cell_right = Cell(1,2)
+        # Create a cell appearing to the bottom of this cell
+        cell_bottom = Cell(2,1)
+        # Create a cell appearing to the left of this cell
+        cell_left = Cell(1,0)
 
-        # Remove the wall to the right
-        cell2 = Cell(1, 0)
-        cell2.remove_walls(1, 2)
-        self.assertEqual(cell.walls, {"top": True, "right": False, "bottom": True, "left": True})
 
-        # Remove the wall to the left
-        cell3 = Cell(0, 2)
-        cell3.remove_walls(0, 1)
-        self.assertEqual(cell.walls, {"top": True, "right": True, "bottom": True, "left": False})
+        # check for walls between all these cells
+        self.assertEqual(cell.is_walls_between(cell_top), True)
+        self.assertEqual(cell.is_walls_between(cell_right), True)
+        self.assertEqual(cell.is_walls_between(cell_bottom), True)
+        self.assertEqual(cell.is_walls_between(cell_left), True)
 
-        # Remove the wall on the top
-        cell4 = Cell(1, 2)
-        cell4.remove_walls(0, 2)
-        self.assertEqual(cell.walls, {"top": False, "right": True, "bottom": True, "left": True})
+        # remove top wall of 'cell' and bottom wall of 'cell_top'
+        cell.remove_walls(0,1)
+        cell_top.remove_walls(1,1)
 
-        # Remove the wall on the bottom
-        cell5 = Cell(2, 2)
-        cell5.remove_walls(3, 2)
-        self.assertEqual(cell.walls, {"top": True, "right": True, "bottom": False, "left": True})
+        # check that there are no walls between these cells
+        self.assertEqual(cell.is_walls_between(cell_top), False)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Changes Made

- In file *src/maze.py*, the function **time.clock** was used for timing. I changed it to **time.time**
- In file *tests/cell_tests.py*, made changes to some tests that were failing

# Why ?

- The function **time.clock** was replaced by **time.time** for compatibility issues. According to the python documentation, the funciton time.clock is deprecated as of version 3.8. I changed this to make the code base compatible with all versions of python.

- In *tests/cell_tests.py*, in line 52, the assertion value has been changed to True. Looking at the method **Cell.set_as_entry_exit**, the second if condition will match and the bottom wall will be removed but the right wall will be as is. Hence the change in assertion.
- In *tests/cell_tests.py*, in line 63, the cell (0,0) is to the left of cell (0,1) and hence left wall will be removed.
- In *tests/cell_tests.py*, the test method **test_is_walls_between** does not test the method **Cell.test_is_walls_between**. Only the **remove_walls** method was called. I rewrote this method to consider that.

## The test_is_walls_between method implementation

This test should test whether there is a wall between any two cells.
In the method, I created a cell which you can imagine to be at the center of a (2x2) maze. I also created 4 other cells, one at each side of this cell (top, bottom, right and left).
So, there should be a wall between the cell at the center all the cells at the sides.
The test also tests whether wall exists between two neighbouring cells if the common wall between them is removed.