### PR TITLE
Added new algorithm and start location feature

### DIFF
--- a/aldous_broder.py
+++ b/aldous_broder.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from src.maze_manager import MazeManager
+from src.maze import Maze
+
+
+if __name__ == "__main__":
+
+    # create a maze manager to handle all operations
+    manager = MazeManager()
+
+    # now create a maze using the binary tree method
+    maze_using_aldous_broder = Maze(9, 7, algorithm="aldous_broder",start_coor=(1,1))
+
+    # add this maze to the maze manager
+    maze_using_aldous_broder = manager.add_existing_maze(maze_using_aldous_broder)
+
+    # show the maze
+    manager.show_maze(maze_using_aldous_broder.id)
+    # show how the maze was generated
+    # TO DO: Fix the animation for this algorithm

--- a/examples/aldous_broder.py
+++ b/examples/aldous_broder.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from src.maze_manager import MazeManager
+from src.maze import Maze
+
+
+if __name__ == "__main__":
+
+    # create a maze manager to handle all operations
+    manager = MazeManager()
+
+    # now create a maze using the binary tree method
+    maze_using_aldous_broder = Maze(9, 7, algorithm="aldous_broder",start_coor=(1,1))
+
+    # add this maze to the maze manager
+    maze_using_aldous_broder = manager.add_existing_maze(maze_using_aldous_broder)
+
+    # show the maze
+    manager.show_maze(maze_using_aldous_broder.id)
+    # show how the maze was generated
+    # TO DO: Fix the animation for this algorithm

--- a/src/algorithm.py
+++ b/src/algorithm.py
@@ -165,3 +165,31 @@ def binary_tree( maze, start_coor ):
 
     print(f"Generating path for maze took {time.time() - begin_time}s.")
     maze.generation_path = path
+
+def aldous_broder(maze, start_coor):
+    width = maze.num_cols
+    height = maze.num_rows
+    x, y = start_coor
+    remaining = width * height
+
+    path = [(x, y)]  # Initialize path with the start coordinates
+
+    while remaining > 0:
+        directions = [(0, 1), (0, -1), (1, 0), (-1, 0)]  # N, S, E, W
+        random.shuffle(directions)
+
+        for dx, dy in directions:
+            nx, ny = x + dx, y + dy
+
+            if 0 <= nx < width and 0 <= ny < height:
+                if not maze.grid[ny][nx].visited:
+                    maze.grid[y][x].remove_walls(ny, nx)
+                    maze.grid[ny][nx].remove_walls(y, x)
+                    maze.grid[ny][nx].visited = True
+                    remaining -= 1
+
+                x, y = nx, ny
+                path.append((x, y))  # Add the new cell to the path
+                break
+
+    maze.generation_path = path  # Assign the path to the maze's generation_path attribute

--- a/src/maze.py
+++ b/src/maze.py
@@ -3,8 +3,7 @@ import random
 import math
 import time
 from src.cell import Cell
-from src.algorithm import depth_first_recursive_backtracker, binary_tree
-
+from src.algorithm import depth_first_recursive_backtracker, binary_tree, aldous_broder
 
 class Maze(object):
     """Class representing a maze; a 2D grid of Cell objects. Contains functions
@@ -23,7 +22,7 @@ class Maze(object):
         grid (list): A copy of initial_grid (possible this is un-needed)
         """
 
-    def __init__(self, num_rows, num_cols, id=0, algorithm = "dfs_backtrack"):
+    def __init__(self, num_rows, num_cols, id=0, algorithm = "dfs_backtrack",start_coor = (0, 0)): 
         """Creates a gird of Cell objects that are neighbors to each other.
 
             Args:
@@ -42,7 +41,7 @@ class Maze(object):
         self.solution_path = None
         self.initial_grid = self.generate_grid()
         self.grid = self.initial_grid
-        self.generate_maze(algorithm, (0, 0))
+        self.generate_maze(algorithm, start_coor = start_coor)
 
     def generate_grid(self):
         """Function that creates a 2D grid of Cell objects. This can be thought of as a
@@ -189,7 +188,7 @@ class Maze(object):
 
         return rng_entry_exit       # Return entry/exit that is different from exit/entry
 
-    def generate_maze(self, algorithm, start_coor = (0, 0)):
+    def generate_maze(self, algorithm, start_coor):
         """This takes the internal grid object and removes walls between cells using the
         depth-first recursive backtracker algorithm.
 
@@ -202,3 +201,5 @@ class Maze(object):
             depth_first_recursive_backtracker(self, start_coor)
         elif algorithm == "bin_tree":
             binary_tree(self, start_coor)
+        elif algorithm == "aldous_broder":
+            aldous_broder(self, start_coor)


### PR DESCRIPTION
# Changes Made

- Added a new algorithm called the "Aldous-Broder Algorithm" to the file **src/algorithm.py**
- Added demo script in examples/aldous_broder.py
- Added an option to set the start point of the algorithm 

# Why?

1. Inspired by Jamis Buck's [blog post](https://weblog.jamisbuck.org/2011/1/17/maze-generation-aldous-broder-algorithm), I wanted to be able to create a maze that has no 'bias' put simply, by using a form of 'random walk' (The most complex maze for the given space)
2. Added an option to define the starting cell for an algorithm to begin at, because this algorithm requires that it starts at a random cell (cell must be chosen randomly by user)


## Aldous-Broder Algorithm

1. Choose a random cell, it is marked as visited and becomes the 'current cell'
2. Of the four neighbors, one is chosen randomly and becomes the 'current cell'
3. If the neighbor cell is 'unvisited', it is marked as 'visited' and the wall between this cell and the previous cell is **removed**. 
If it's already 'visited', the wall is **not removed** between this cell and the previous cell
4. Repeat steps 2-3 until all cells are marked as 'visited'



* Currently it was tested and works only with 'show_maze' function, and it doesn't work for example with show_generation_animation
